### PR TITLE
pin to version 3.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   jekyll:
-    image: jekyll/jekyll
+    image: jekyll/jekyll:3.8
     ports:
       - "4000:4000"
     volumes:


### PR DESCRIPTION
This will make it so that caching the build step actually works